### PR TITLE
Fix for connection pooling.

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>com.hmsonline</groupId>
 			<artifactId>hms-cassandra-triggers</artifactId>
-			<version>0.14.1</version>
+			<version>0.14.5</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>guava</artifactId>

--- a/server/src/main/java/com/hmsonline/virgil/pool/ConnectionPool.java
+++ b/server/src/main/java/com/hmsonline/virgil/pool/ConnectionPool.java
@@ -13,7 +13,7 @@ public class ConnectionPool {
     private static Logger logger = LoggerFactory.getLogger(ConnectionPool.class);
     // TODO: May want this to match the HTTP thread configuration.
     private static final int MAX_POOL_SIZE = 100;
-    private static final int MAX_TRIES_FOR_CONNECTION = 10;
+    private static final int MAX_TRIES_FOR_CONNECTION = 2;
     private static final int CONNECTION_WAIT_TIME = 500;
     private static Object LOCK = new Object();
 

--- a/server/src/main/java/com/hmsonline/virgil/pool/VirgilConnection.java
+++ b/server/src/main/java/com/hmsonline/virgil/pool/VirgilConnection.java
@@ -1,0 +1,73 @@
+package com.hmsonline.virgil.pool;
+
+import java.util.Date;
+import java.util.UUID;
+
+import org.apache.cassandra.thrift.Cassandra;
+import org.apache.cassandra.thrift.CassandraServer;
+import org.apache.cassandra.thrift.TBinaryProtocol;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.transport.TFramedTransport;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.hmsonline.virgil.config.VirgilConfiguration;
+
+public class VirgilConnection {
+    private static Logger logger = LoggerFactory.getLogger(VirgilConnection.class);
+
+    private TTransport transport = null;
+    private TSocket socket = null;
+    private Cassandra.Iface connection = null;
+    private UUID id = null;
+    private long createTime;
+
+    public VirgilConnection(boolean embedded) throws TTransportException {
+        id = UUID.randomUUID();
+        createTime = System.currentTimeMillis();
+        logger.debug("Created connection [" + this.id + "] at [" + new Date(this.createTime) + "]");
+        if (!embedded) {
+            this.socket = new TSocket(VirgilConfiguration.getHost(), VirgilConfiguration.getPort());
+            this.transport = new TFramedTransport(socket);
+            TProtocol proto = new TBinaryProtocol(transport);
+            this.connection = new Cassandra.Client(proto);
+            transport.open();
+        } else {
+            this.connection = new CassandraServer();
+        }
+    }
+
+    public Cassandra.Iface getThriftConnection() {
+        return connection;
+    }
+
+    public void open() throws TTransportException {
+        logger.debug("Opening connection [" + this.id + "] created at [" + new Date(this.createTime) + "]");
+        transport.open();
+    }
+
+    public void close() {
+        logger.debug("Closing connection [" + this.id + "] created at [" + new Date(this.createTime) + "]");
+        if (transport != null && transport.isOpen()) {
+            try {
+                transport.flush();
+            } catch (Exception e) {
+                logger.error("Could not flush thrift transport." + toString(), e.getMessage());
+            } finally {
+                try {
+                    transport.close();
+                    socket.close();
+                } catch (Exception e) {
+                    logger.error("Could not close thrift transport (okay if the server has gone away).", e);
+                }
+            }
+        }
+    }
+
+    public UUID getId() {
+        return id;
+    }
+}

--- a/server/src/test/java/com/hmsonline/virgil/VirgilServerTest.java
+++ b/server/src/test/java/com/hmsonline/virgil/VirgilServerTest.java
@@ -3,7 +3,7 @@ package com.hmsonline.virgil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
-public class VirgilServerTest {
+public abstract class VirgilServerTest {
     static Thread serverThread = null;
 
     @BeforeClass


### PR DESCRIPTION
I added a VirgilConnection class to encapsulate the transport and the Cassandra.IFace.
The actual fix was to change the ConnectionPool.release line to return the NEW connection to the pool instead of the potentially broken connection.
